### PR TITLE
Fix docker setup for git submodules

### DIFF
--- a/docker/unitree/agents/Dockerfile
+++ b/docker/unitree/agents/Dockerfile
@@ -100,6 +100,13 @@ COPY requirements.txt /app/
 
 WORKDIR /app
 
+# Copy git configuration files first to initialize submodules
+COPY .gitmodules ./
+COPY .git ./.git
+
+# Initialize and update submodules
+RUN git submodule init && git submodule update --recursive
+
 # Install dimos requirements
 RUN pip install --no-cache-dir -r requirements.txt
 
@@ -128,7 +135,7 @@ COPY docker/unitree/agents/supervisord.conf /etc/supervisor/conf.d/supervisord.c
 COPY docker/unitree/agents/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Copy dimos and tests
+# Copy dimos and tests after submodules are initialized
 COPY dimos /app/dimos/
 COPY tests /app/tests
 COPY dimos/__init__.py /app/__init__.py

--- a/docker/unitree/agents_interface/Dockerfile
+++ b/docker/unitree/agents_interface/Dockerfile
@@ -40,6 +40,8 @@ RUN apt-get update && apt-get install -y \
     qt5-qmake \
     qtbase5-dev-tools \
     supervisor \
+    screen \
+    tmux \
     && rm -rf /var/lib/apt/lists/*
 
 # Install specific numpy version first
@@ -102,6 +104,13 @@ COPY base-requirements.txt /app/
 
 WORKDIR /app
 
+# Copy git configuration files first to initialize submodules
+COPY .gitmodules ./
+COPY .git ./.git
+
+# Initialize and update submodules
+RUN git submodule init && git submodule update --recursive
+
 # Install torch and torchvision first due to builds in requirements.txt
 RUN pip install --no-cache-dir -r base-requirements.txt
 
@@ -133,7 +142,7 @@ COPY docker/unitree/agents_interface/supervisord.conf /etc/supervisor/conf.d/sup
 COPY docker/unitree/agents_interface/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Copy dimos and tests
+# Copy dimos and tests after submodules are initialized
 COPY dimos /app/dimos/
 COPY tests /app/tests
 COPY dimos/__init__.py /app/__init__.py

--- a/docker/unitree/ros_dimos/Dockerfile
+++ b/docker/unitree/ros_dimos/Dockerfile
@@ -98,6 +98,13 @@ COPY requirements.txt /app/
 
 WORKDIR /app
 
+# Copy git configuration files first to initialize submodules
+COPY .gitmodules ./
+COPY .git ./.git
+
+# Initialize and update submodules
+RUN git submodule init && git submodule update --recursive
+
 # Install dimos requirements
 RUN pip install --no-cache-dir -r requirements.txt
 
@@ -118,7 +125,7 @@ RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /root/.bashrc && \
     echo "source /ros2_ws/install/setup.bash" >> /root/.bashrc
 
 # Set environment variables
-# webrtc or cyclonedds
+# webrtc or cyclonedx
 ENV CONN_TYPE="webrtc" 
 ENV WEBRTC_SERVER_HOST="0.0.0.0"
 ENV WEBRTC_SERVER_PORT="9991"
@@ -132,6 +139,7 @@ COPY docker/unitree/ros_dimos/supervisord.conf /etc/supervisor/conf.d/supervisor
 COPY docker/unitree/ros_dimos/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# Copy dimos and tests after submodules are initialized
 COPY dimos /app/dimos/
 COPY tests /app/tests/
 

--- a/docker/unitree/webrtc/Dockerfile
+++ b/docker/unitree/webrtc/Dockerfile
@@ -13,18 +13,25 @@ RUN apt-get update && apt-get install -y \
     make \
     portaudio19-dev \
     python3-pyaudio \
-    python3-all-dev
+    python3-all-dev \
+    git
 
 WORKDIR /app
 
-COPY requirements.txt ./
+# Copy git configuration files first
+COPY .gitmodules ./
+COPY .git ./.git
 
+# Initialize and update submodules
+RUN git submodule init && git submodule update --recursive
+
+# Copy requirements and install dependencies
+COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Copy the rest of the code
 COPY ./dimos ./dimos
-
 COPY ./tests ./tests
-
 COPY ./dimos/__init__.py ./
 
 CMD [ "python", "-m", "dimos.robot.unitree.unitree_go2" ]


### PR DESCRIPTION
Automatically initialize git submodules in Docker builds to resolve "module not found" errors.

The Docker containers were failing because git submodules within the `dimos` directory (e.g., `go2_webrtc_connect`, `go2_ros2_sdk`) were not being initialized during the build process. This PR adds steps to copy the `.git` and `.gitmodules` files, then run `git submodule init` and `git submodule update --recursive` in the Dockerfiles, ensuring all required submodules are present and accessible at runtime.